### PR TITLE
Use () rather than _

### DIFF
--- a/src/App/component.js
+++ b/src/App/component.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react'
 
 import Counter from '../Counter'
 
-export default _ => (
+export default () => (
   <Fragment>
     <Counter />
   </Fragment>

--- a/src/Counter/container.js
+++ b/src/Counter/container.js
@@ -8,7 +8,7 @@ const mapStateToProps = state => ({
 })
 
 const mapDispatchToProps = dispatch => ({
-  increment: _ => dispatch(increment())
+  increment: () => dispatch(increment())
 })
 
 export default connect(

--- a/src/ducks/counter.js
+++ b/src/ducks/counter.js
@@ -1,6 +1,6 @@
 export const INCREMENT = 'INCREMENT'
 
-export const increment = _ => ({
+export const increment = () => ({
   type: INCREMENT
 })
 


### PR DESCRIPTION
Using _ gives functions a length of 1 even though they don't take any
parameters